### PR TITLE
feat: feed query

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,34 +1,9 @@
-import { useState } from 'react'
-import reactLogo from '../assets/react.svg'
-import viteLogo from '/vite.svg'
-import '../styles/App.css'
+// import '../styles/App.css'
+import LinkList from './LinkList'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <LinkList />
   )
 }
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,19 @@
+export type LinkType = {
+  id: string
+  description: string
+  url: string
+  createdAt: string
+}
+
+function Link(props: { link: LinkType }) {
+  const { link } = props
+  return (
+    <div>
+      <div>
+        {link.description} ({link.url})
+      </div>
+    </div>
+  )
+}
+
+export default Link

--- a/src/components/LinkList.tsx
+++ b/src/components/LinkList.tsx
@@ -1,0 +1,34 @@
+import { gql, useQuery } from '@apollo/client';
+import Link, { type LinkType } from './Link';
+
+const FEED_QUERY = gql`
+{
+  feed {
+    id
+    links {
+      id
+      createdAt
+      url
+      description
+    }
+  }
+}
+`
+
+function LinkList() {
+  const { data } = useQuery(FEED_QUERY)
+
+  return (
+    <div>
+      {data && (
+        <>
+          {data.feed.links.map((link: LinkType) => (
+            <Link key={link.id} link={link} />
+          ))}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default LinkList;


### PR DESCRIPTION
ref : https://www.howtographql.com/react-apollo/2-queries-loading-links/

# やったこと
* feedを取得する、GraphQL documentを実装
* 上記で実装したGraphQL documentを、apollo-clientのuseQueryでapollo-serverから取得する